### PR TITLE
fix: repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ auto main(int argc, char* argv[]) -> int {
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=creeper5820/creeper-qt&type=Date)](https://www.star-history.com/#creeper5820/creeper-qt&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=creeper5820/creeper-qt&type=Date)](https://star-history.dera.page/#creeper5820/creeper-qt&Date)
 
 </div>
 


### PR DESCRIPTION
The star history chart in the README was broken due to GitHub stargazer API restrictions that the previous provider relied on, so it no longer renders for visitors.

This switches the chart to the star-history.dera.page mirror, which uses an alternative data source that requires no API token and is already adopted by repositories with hundreds of thousands of stargazers. The chart now works again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新项目统计中的 Star History 图表及跳转链接，确保链接指向最新地址。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->